### PR TITLE
Rename InGen.FTSO to FTSO Asia

### DIFF
--- a/bifrost-wallet.providerlist.json
+++ b/bifrost-wallet.providerlist.json
@@ -642,7 +642,7 @@
       "chainId": 19,
       "name": "FTSO Asia",
       "description": "We are an Asian dynamic data provider for the FTSO bringing growth to the decentralized Flare.",
-      "url": "https://www.asia.ingen.com.ph",
+      "url": "https://asia.ingen.com.ph",
       "address": "0x664e070592063bFE5072F0aC25C6C11e5ccF9928",
       "logoURI": "https://raw.githubusercontent.com/TowoLabs/ftso-signal-providers/master/assets/0x664e070592063bFE5072F0aC25C6C11e5ccF9928.png",
       "listed": true
@@ -651,7 +651,7 @@
       "chainId": 14,
       "name": "FTSO Asia",
       "description": "We are an Asian dynamic data provider for the FTSO bringing growth to the decentralized Flare.",
-      "url": "https://www.asia.ingen.com.ph",
+      "url": "https://asia.ingen.com.ph",
       "address": "0xdd7B2Bac728f027f23aDD7128711ecB60f761aD5",
       "logoURI": "https://raw.githubusercontent.com/TowoLabs/ftso-signal-providers/master/assets/0xdd7B2Bac728f027f23aDD7128711ecB60f761aD5.png",
       "listed": true

--- a/bifrost-wallet.providerlist.json
+++ b/bifrost-wallet.providerlist.json
@@ -640,18 +640,18 @@
     },
     {
       "chainId": 19,
-      "name": "InGen.FTSO",
+      "name": "FTSO Asia",
       "description": "We are an Asian dynamic data provider for the FTSO bringing growth to the decentralized Flare.",
-      "url": "https://www.ftso.ingen.com.ph",
+      "url": "https://www.asia.ingen.com.ph",
       "address": "0x664e070592063bFE5072F0aC25C6C11e5ccF9928",
       "logoURI": "https://raw.githubusercontent.com/TowoLabs/ftso-signal-providers/master/assets/0x664e070592063bFE5072F0aC25C6C11e5ccF9928.png",
       "listed": true
     },
     {
       "chainId": 14,
-      "name": "InGen.FTSO",
+      "name": "FTSO Asia",
       "description": "We are an Asian dynamic data provider for the FTSO bringing growth to the decentralized Flare.",
-      "url": "https://www.ftso.ingen.com.ph",
+      "url": "https://www.asia.ingen.com.ph",
       "address": "0xdd7B2Bac728f027f23aDD7128711ecB60f761aD5",
       "logoURI": "https://raw.githubusercontent.com/TowoLabs/ftso-signal-providers/master/assets/0xdd7B2Bac728f027f23aDD7128711ecB60f761aD5.png",
       "listed": true


### PR DESCRIPTION
Just to make sure that InGen.FTSO is completely renamed to FTSO Asia. Other site still shows its InGen and some some sites its FTSO Asia.