### PR TITLE
Update bifrost-wallet.providerlist.json for XTerraMetrics provider

### DIFF
--- a/bifrost-wallet.providerlist.json
+++ b/bifrost-wallet.providerlist.json
@@ -1946,6 +1946,7 @@
       "url": "https://www.xterrametrics.com",
       "address": "0xB0840104E84DA02254B043Fd4C205415E759Bf1E",
       "logoURI": "https://raw.githubusercontent.com/TowoLabs/ftso-signal-providers/master/assets/0xB0840104E84DA02254B043Fd4C205415E759Bf1E.png"
+      "listed": true
     },
     {
       "chainId": 14,


### PR DESCRIPTION
Added "listed: true" to XTerraMetrics provider to correct not being able to be searched in the delegation search field. We have been submitting prices for 5 months now and have maintained an availability of 99% to 100% would like to hopefully get the "listed" status. Here is a link showing our recent availability and success rates. 

https://songbird-systems-explorer.flare.rocks/providers/ftso/0xEd1AF13D359044Eea494cb9Acf03997caBfFD44b

Please let me know what we can do to improve if needed for the listed status.